### PR TITLE
feat: offline loan dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# LoanDash
+
+Standalone offline dashboard for viewing loan document analysis JSON files.
+
+## Generate JSON
+
+Use the prompt in [`PromptV2.txt`](PromptV2.txt) with your language model to produce a structured JSON analysis of a loan agreement.
+
+## Use the dashboard
+
+1. Open `index.html` in any modern browser (no server required).
+2. Click **Add JSON** or drag one or more JSON files onto the page.
+3. Switch between loans, filter items, and export CSV summaries as needed.
+4. Use **Save Dashboard** to download a copy of the page with loaded data for offline sharing.
+
+The page is completely self-contained and does not require an internet connection.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Loan Agreement JSON Dashboard — Multi & Portfolio (Fixed)</title>
+  <title>Loan Agreement JSON Dashboard</title>
   <style>
     :root{
       --bg:#0b1020;
@@ -111,6 +111,7 @@
         </label>
         <button class="btn" id="pasteBtn" title="Paste raw JSON">📋 Paste JSON</button>
         <button class="btn" id="saveHtmlBtn" title="Download this dashboard file">💾 Save Dashboard</button>
+        <a class="btn" href="PromptV2.txt" target="_blank" title="View JSON prompt">📝 Prompt</a>
         <button class="btn ghost" id="exportCsvBtn" disabled>⬇️ Export Items CSV</button>
         <button class="btn ghost" id="exportTermCsvBtn" disabled>⬇️ Export Term Sheet CSV</button>
         <button class="btn ghost" id="exportPortfolioCsvBtn" disabled>⬇️ Export Portfolio CSV</button>
@@ -1033,7 +1034,7 @@
   // Save the current HTML file for portability
   $('#saveHtmlBtn').onclick = ()=>{
     const html = document.documentElement.outerHTML;
-    download('loan_dashboard_multi_portfolio_fixed.html', html);
+    download('index.html', html);
   };
 
   // ---------- Boot ----------


### PR DESCRIPTION
## Summary
- rename loan dashboard to `index.html` and tweak title
- add link to `PromptV2.txt` and update save behavior for offline use
- document usage of the offline dashboard in new README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb981c1e088323bcc9792142bf6338